### PR TITLE
Hotfix 2.1.1

### DIFF
--- a/dive_content/fields.py
+++ b/dive_content/fields.py
@@ -20,6 +20,10 @@ from .widgets import (
 
 
 class AdaptedSimpleArrayField(SimpleArrayField):
+    def __init__(self, *args, **kwargs):
+        kwargs["show_hidden_initial"] = False
+        super().__init__(*args, **kwargs)
+
     def prepare_value(self, value):
         return value
 

--- a/dive_content/outputs.py
+++ b/dive_content/outputs.py
@@ -129,6 +129,8 @@ class PlantOutput:
             obj.get_status_display(),
             obj.other_features,
         ]
+        fields[1] = fields[1].replace("r ", " ", 1).replace("s ", " ", 1)
+        fields[2] = f"({fields[2]})" if fields[2] else ""
         fields[3] = format_enumeration(fields[3], "oder")
         fields[5] = format_FloatRangeTermCharField(fields[5])
         if fields[7] == "Sporenpflanze":

--- a/dive_content/templates/output.html
+++ b/dive_content/templates/output.html
@@ -1,5 +1,5 @@
-<div class="readonly" style="color: #000000;">
-    {% if widget.value != None %}<i>"{{ widget.value|stringformat:'s' }}"</i>
+<div class="readonly" style="color: #2f7692;">
+    {% if widget.value != None %}{{ widget.value|stringformat:'s' }}
     {% else %}<span style="color: #ff0000;">Keine Ausgabe</span>
     {% endif %}
 </div>


### PR DESCRIPTION
- Ausgabe "Allgemeines" der Kategorie "Allgemein" korrigiert
  - Artname in Klammern gesetzt
  - Trivialnamen, die eine Wortverbindung mit einem Adjektiv sind, werden automatisch grammatikalisch angepasst
- Formfeld von Array-Feldern angepasst
  - Models mit Array-Feldern wurden immer erstellt, auch wenn nichts eingegeben oder geändert wurde, da die `has_change`-Funktion der Formfelder immer `True` ausgegeben hatte
- Anzeige der Ausgabesätze im Admin-Interface angepasst
  - Statt schwarz, in Anführungszeichen und kursiv nur farblich abgesetzt